### PR TITLE
fix: tighten tenv release download curls

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -147,7 +147,11 @@ runs:
 
         # Determine which version to download
         if [ -z "${REQUESTED_VERSION}" ]; then
-          TENV_VERSION=$(curl -s https://api.github.com/repos/tofuutils/tenv/releases/latest | grep -o '"tag_name": ".*"' | cut -d'"' -f4)
+          TENV_VERSION=$(curl -fsSL \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/tofuutils/tenv/releases/latest | grep -o '"tag_name": ".*"' | cut -d'"' -f4)
         else
           # Keep the 'v' prefix for GitHub releases if it doesn't exist
           if [[ "${REQUESTED_VERSION}" == v* ]]; then
@@ -163,15 +167,15 @@ runs:
         RELEASE_URL="https://github.com/tofuutils/tenv/releases/download/${TENV_VERSION}"
 
         # Download the tarball and its signature files
-        curl -sL -o "${TEMP_DIR}/${TARBALL_NAME}" "${RELEASE_URL}/${TARBALL_NAME}"
-        curl -sL -o "${TEMP_DIR}/${TARBALL_NAME}.sig" "${RELEASE_URL}/${TARBALL_NAME}.sig"
-        curl -sL -o "${TEMP_DIR}/${TARBALL_NAME}.pem" "${RELEASE_URL}/${TARBALL_NAME}.pem"
+        curl -fsSL -o "${TEMP_DIR}/${TARBALL_NAME}" "${RELEASE_URL}/${TARBALL_NAME}"
+        curl -fsSL -o "${TEMP_DIR}/${TARBALL_NAME}.sig" "${RELEASE_URL}/${TARBALL_NAME}.sig"
+        curl -fsSL -o "${TEMP_DIR}/${TARBALL_NAME}.pem" "${RELEASE_URL}/${TARBALL_NAME}.pem"
 
         # Download checksums and signature files
         CHECKSUMS_FILE="tenv_${TENV_VERSION}_checksums.txt"
-        curl -sL -o "${TEMP_DIR}/${CHECKSUMS_FILE}" "${RELEASE_URL}/${CHECKSUMS_FILE}"
-        curl -sL -o "${TEMP_DIR}/${CHECKSUMS_FILE}.sig" "${RELEASE_URL}/${CHECKSUMS_FILE}.sig"
-        curl -sL -o "${TEMP_DIR}/${CHECKSUMS_FILE}.pem" "${RELEASE_URL}/${CHECKSUMS_FILE}.pem"
+        curl -fsSL -o "${TEMP_DIR}/${CHECKSUMS_FILE}" "${RELEASE_URL}/${CHECKSUMS_FILE}"
+        curl -fsSL -o "${TEMP_DIR}/${CHECKSUMS_FILE}.sig" "${RELEASE_URL}/${CHECKSUMS_FILE}.sig"
+        curl -fsSL -o "${TEMP_DIR}/${CHECKSUMS_FILE}.pem" "${RELEASE_URL}/${CHECKSUMS_FILE}.pem"
 
         # Verify checksums signature
         echo "Verifying checksums signature..."


### PR DESCRIPTION
This updates the tenv download step to authenticate only the GitHub API latest-release lookup while keeping public release asset downloads unauthenticated. It also makes every curl fail on HTTP errors so the action stops cleanly instead of downloading invalid files.

- add Bearer auth and explicit GitHub API headers to the latest release lookup
- switch release asset and checksum downloads from `-sL` to `-fsSL` for fail-fast behavior