### PR TITLE
chore: harden GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
       day: "friday"
       time: "08:00"
       timezone: "Australia/Perth"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,17 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
+    name: Test ${{ matrix.tool }} on ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -13,6 +22,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup tenv
         uses: ./
         with:
@@ -23,7 +34,8 @@ jobs:
           which tenv
           tenv version
       - name: Verify tool
+        env:
+          TOOL_NAME: ${{ matrix.tool }}
         run: |
-          which ${{ matrix.tool }}
-          ${{ matrix.tool }} version
-
+          which "$TOOL_NAME"
+          "$TOOL_NAME" version

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: Run zizmor
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # Needed for zizmor-action to upload SARIF results to GitHub code scanning.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,6 +22,16 @@ vars:
   NEW_MAJOR_VERSION: "v{{.NEXT_MAJOR}}.0.0"
 
 tasks:
+  zizmor:
+    desc: Audit GitHub Actions workflows and action metadata with zizmor
+    cmds:
+      - zizmor .
+
+  fix:
+    desc: Apply safe zizmor auto-fixes
+    cmds:
+      - zizmor --fix=safe .
+
   _preflight:
     internal: true
     desc: Validate branch and remote state before releasing

--- a/action.yml
+++ b/action.yml
@@ -20,12 +20,13 @@ runs:
     - name: Resolve tenv version
       id: resolve-tenv-version
       shell: bash
+      env:
+        REQUESTED_VERSION: ${{ inputs.tenv-version }}
+        GH_TOKEN: ${{ github.token }}
       run: |
-        REQUESTED_VERSION="${{ inputs.tenv-version }}"
-
         if [ -z "${REQUESTED_VERSION}" ]; then
           RESOLVED_VERSION=$(curl -fsSL \
-            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/tofuutils/tenv/releases/latest | grep -o '"tag_name": ".*"' | cut -d'"' -f4)
@@ -37,8 +38,13 @@ runs:
           fi
         fi
 
-        echo "resolved-version=${RESOLVED_VERSION}" >> $GITHUB_OUTPUT
-        echo "normalized-version=${RESOLVED_VERSION#v}" >> $GITHUB_OUTPUT
+        if [[ ! "${RESOLVED_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Invalid tenv version: ${RESOLVED_VERSION}" >&2
+          exit 1
+        fi
+
+        echo "resolved-version=${RESOLVED_VERSION}" >> "$GITHUB_OUTPUT"
+        echo "normalized-version=${RESOLVED_VERSION#v}" >> "$GITHUB_OUTPUT"
 
     - name: Restore tool cache
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -50,6 +56,9 @@ runs:
     - name: Check for cached tenv
       id: check-tenv
       shell: bash
+      env:
+        RESOLVED_VERSION: ${{ steps.resolve-tenv-version.outputs.resolved-version }}
+        NORMALIZED_VERSION: ${{ steps.resolve-tenv-version.outputs.normalized-version }}
       run: |
         # Determine OS and architecture (must match tenv release asset naming)
         OS=$(uname -s)
@@ -60,9 +69,6 @@ runs:
             ;;
         esac
 
-        RESOLVED_VERSION="${{ steps.resolve-tenv-version.outputs.resolved-version }}"
-        NORMALIZED_VERSION="${{ steps.resolve-tenv-version.outputs.normalized-version }}"
-
         # Tool cache convention: <tool>/<version>/<arch>/
         INSTALL_DIR="${RUNNER_TOOL_CACHE}/tenv/${NORMALIZED_VERSION}/${ARCH}"
         TENV_ROOT_DIR="${INSTALL_DIR}/root"
@@ -70,20 +76,20 @@ runs:
         TENV_PATH="${TENV_BIN_DIR}/tenv"
         COMPLETE_MARKER="${RUNNER_TOOL_CACHE}/tenv/${NORMALIZED_VERSION}/${ARCH}.complete"
 
-        echo "install-dir=${INSTALL_DIR}" >> $GITHUB_OUTPUT
-        echo "bin-dir=${TENV_BIN_DIR}" >> $GITHUB_OUTPUT
-        echo "tenv-root=${TENV_ROOT_DIR}" >> $GITHUB_OUTPUT
-        echo "os=${OS}" >> $GITHUB_OUTPUT
-        echo "arch=${ARCH}" >> $GITHUB_OUTPUT
-        echo "resolved-version=${RESOLVED_VERSION}" >> $GITHUB_OUTPUT
-        echo "normalized-version=${NORMALIZED_VERSION}" >> $GITHUB_OUTPUT
+        echo "install-dir=${INSTALL_DIR}" >> "$GITHUB_OUTPUT"
+        echo "bin-dir=${TENV_BIN_DIR}" >> "$GITHUB_OUTPUT"
+        echo "tenv-root=${TENV_ROOT_DIR}" >> "$GITHUB_OUTPUT"
+        echo "os=${OS}" >> "$GITHUB_OUTPUT"
+        echo "arch=${ARCH}" >> "$GITHUB_OUTPUT"
+        echo "resolved-version=${RESOLVED_VERSION}" >> "$GITHUB_OUTPUT"
+        echo "normalized-version=${NORMALIZED_VERSION}" >> "$GITHUB_OUTPUT"
 
         if [ -f "${COMPLETE_MARKER}" ] && [ -f "${TENV_PATH}" ] && [ -x "${TENV_PATH}" ]; then
           echo "Found cached tenv ${NORMALIZED_VERSION} at ${TENV_BIN_DIR}"
-          echo "found=true" >> $GITHUB_OUTPUT
+          echo "found=true" >> "$GITHUB_OUTPUT"
         else
           echo "No cached tenv ${NORMALIZED_VERSION} found"
-          echo "found=false" >> $GITHUB_OUTPUT
+          echo "found=false" >> "$GITHUB_OUTPUT"
           mkdir -p "${TENV_BIN_DIR}"
         fi
 
@@ -94,13 +100,13 @@ runs:
     - name: Download and verify tenv
       if: steps.check-tenv.outputs.found != 'true'
       shell: bash
+      env:
+        BIN_DIR: ${{ steps.check-tenv.outputs.bin-dir }}
+        OS: ${{ steps.check-tenv.outputs.os }}
+        ARCH: ${{ steps.check-tenv.outputs.arch }}
+        TENV_VERSION: ${{ steps.check-tenv.outputs.resolved-version }}
+        NORMALIZED_VERSION: ${{ steps.check-tenv.outputs.normalized-version }}
       run: |
-        # Set variables
-        BIN_DIR="${{ steps.check-tenv.outputs.bin-dir }}"
-        OS="${{ steps.check-tenv.outputs.os }}"
-        ARCH="${{ steps.check-tenv.outputs.arch }}"
-        TENV_VERSION="${{ steps.check-tenv.outputs.resolved-version }}"
-        NORMALIZED_VERSION="${{ steps.check-tenv.outputs.normalized-version }}"
         TEMP_DIR=$(mktemp -d)
 
         # Download tenv archive and verification files
@@ -156,13 +162,17 @@ runs:
 
     - name: Add tenv to path
       shell: bash
-      run: |
-        echo "${{ steps.check-tenv.outputs.bin-dir }}" >> $GITHUB_PATH
+      env:
+        TENV_BIN_DIR: ${{ steps.check-tenv.outputs.bin-dir }}
+      run: | # zizmor: ignore[github-env] TENV_BIN_DIR is derived from RUNNER_TOOL_CACHE and validated semver/runner architecture
+        echo "${TENV_BIN_DIR}" >> "$GITHUB_PATH"
 
     - name: Set TENV_ROOT
       shell: bash
-      run: |
-        echo "TENV_ROOT=${{ steps.check-tenv.outputs.tenv-root }}" >> $GITHUB_ENV
+      env:
+        TENV_ROOT_DIR: ${{ steps.check-tenv.outputs.tenv-root }}
+      run: | # zizmor: ignore[github-env] TENV_ROOT_DIR is derived from RUNNER_TOOL_CACHE and validated semver/runner architecture
+        echo "TENV_ROOT=${TENV_ROOT_DIR}" >> "$GITHUB_ENV"
 
     - name: Install tool with tenv
       shell: bash
@@ -171,4 +181,4 @@ runs:
         TOOL_VERSION: ${{ inputs.tool-version }}
         TENV_GITHUB_TOKEN: ${{ github.token }}
       run: |
-        tenv $TOOL_NAME install $TOOL_VERSION
+        tenv "$TOOL_NAME" install "$TOOL_VERSION"


### PR DESCRIPTION
Hardens the repository's GitHub Actions surface and adds ongoing zizmor auditing so future workflow changes are checked automatically. The changes address composite action shell interpolation, workflow permissions, Dependabot pacing, and local Taskfile shortcuts for the audit commands.

- Harden composite action shell handling by moving GitHub expressions into environment variables, validating the resolved tenv version as semver, and quoting environment-file writes and command arguments.
- Restrict the test workflow with least-privilege permissions, checkout credential persistence disabled, concurrency, a named matrix job, and safer matrix value use in shell.
- Add a Dependabot cooldown for GitHub Actions updates.
- Add a pinned zizmor workflow for pull requests and main pushes with SARIF upload permissions documented inline.
- Add Taskfile tasks for running zizmor audits and safe auto-fixes locally.